### PR TITLE
Pass OCP_Defaults instance to LoginController constructor for NX13

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,7 @@ the following form explains the usage  of this plugin:
         </form>
     </body>
 </html>
+
+For use this plugin you need to edit core file in your nextcloud installation folder - lib/private/AppFramework/Http/Request.php#503 -> add "return FALSE;".
+
 ```

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -31,12 +31,6 @@ if($currentUrl !== $expectedUrl && !defined('PHPUNIT_BYPASS_URL')) {
 
 // Register the request service again
 $serverContainer->registerService('Request', function() use ($serverContainer) {
-	if (isset($serverContainer['urlParams'])) {
-		$urlParams = $this['urlParams'];
-	} else {
-		$urlParams = [];
-	}
-
 	if (defined('PHPUNIT_RUN') && PHPUNIT_RUN
 		&& in_array('fakeinput', stream_get_wrappers())
 	) {
@@ -56,7 +50,7 @@ $serverContainer->registerService('Request', function() use ($serverContainer) {
 			'method' => (isset($_SERVER) && isset($_SERVER['REQUEST_METHOD']))
 				? $_SERVER['REQUEST_METHOD']
 				: null,
-			'urlParams' => $urlParams,
+			'urlParams' => isset($serverContainer['urlParams']) ? $serverContainer['urlParams'] : [],
 		],
 		$serverContainer->getSecureRandom(),
 		$serverContainer->getConfig(),

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -30,7 +30,13 @@ if($currentUrl !== $expectedUrl && !defined('PHPUNIT_BYPASS_URL')) {
 }
 
 // Register the request service again
-$serverContainer->registerService('Request', function() use ($serverContainer) {
+$serverContainer->registerService('Request', function($c) {
+	if (isset($c['urlParams'])) {
+		$urlParams = $c['urlParams'];
+	} else {
+		$urlParams = [];
+	}
+
 	if (defined('PHPUNIT_RUN') && PHPUNIT_RUN
 		&& in_array('fakeinput', stream_get_wrappers())
 	) {
@@ -49,12 +55,12 @@ $serverContainer->registerService('Request', function() use ($serverContainer) {
 			'cookies' => $_COOKIE,
 			'method' => (isset($_SERVER) && isset($_SERVER['REQUEST_METHOD']))
 				? $_SERVER['REQUEST_METHOD']
-				: null,
-			'urlParams' => isset($serverContainer['urlParams']) ? $serverContainer['urlParams'] : [],
+				: NULL,
+			'urlParams' => $urlParams,
 		],
-		$serverContainer->getSecureRandom(),
-		$serverContainer->getConfig(),
-		$serverContainer->getCsrfTokenManager(),
+		$c->getSecureRandom(),
+		$c->getConfig(),
+		$c->getCsrfTokenManager(),
 		$stream
 	);
 });

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -30,7 +30,7 @@ the following form explains the usage  of this plugin:
 	<bugs>https://github.com/nextcloud/loginviapost/issues</bugs>
 	<repository>https://github.com/nextcloud/loginviapost</repository>
 	<dependencies>
-		<nextcloud min-version="11" max-version="13"/>
+		<nextcloud min-version="14" max-version="14"/>
 	</dependencies>
 	<types>
 		<session/>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@ the following form explains the usage  of this plugin:
     </body>
 </html>
 ```]]></description>
-	<version>1.0.6</version>
+	<version>1.1.0</version>
 	<licence>agpl</licence>
 	<author>Lukas Reschke</author>
 	<namespace>LoginViaPost</namespace>

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -49,8 +49,8 @@ class LoginController extends Controller {
 	private $logger;
 	/** @var Manager */
 	private $twoFactorAuthManager;
-    /** @var Defaults */
-    private $defaults;
+	/** @var Defaults */
+	private $defaults;
 
 	public function __construct($appName,
 								IRequest $request,
@@ -60,8 +60,9 @@ class LoginController extends Controller {
 								IConfig $config,
 								ISession $session,
 								ILogger $logger,
-								Manager $twoFactorAuthManager) {
-		parent::__construct($appName, $request);
+								Manager $twoFactorAuthManager)
+	{
+		parent::__construct($appName, \OC::$server->getRequest());
 		$this->urlGenerator = $urlGenerator;
 		$this->userSession = $userSession;
 		$this->userManager = $userManager;
@@ -69,7 +70,7 @@ class LoginController extends Controller {
 		$this->session = $session;
 		$this->logger = $logger;
 		$this->twoFactorAuthManager = $twoFactorAuthManager;
-        $this->defaults = new \OCP\Defaults();
+		$this->defaults = new \OCP\Defaults();
 	}
 
 	private function getMockedRequest() {
@@ -85,7 +86,7 @@ class LoginController extends Controller {
 					? $_SERVER['REQUEST_METHOD']
 					: null,
 			],
-			null,
+			NULL,
 			$this->config
 		);
 	}
@@ -101,66 +102,21 @@ class LoginController extends Controller {
 	 * @return RedirectResponse
 	 */
 	public function login($username, $password) {
-		$class = new \ReflectionClass(\OC\Core\Controller\LoginController::class);
-		$parameters = $class->getConstructor()->getParameters();
-
 		/** @var \OC\Core\Controller\LoginController $loginController */
-        if(\OCP\Util::getVersion()[0] >= 13) {
-            if($parameters[8]->getName() === 'throttler') {
-                $loginController = new \OC\Core\Controller\LoginController(
-                    'core',
-                    $this->getMockedRequest(),
-                    $this->userManager,
-                    $this->config,
-                    $this->session,
-                    $this->userSession,
-                    $this->urlGenerator,
-                    $this->twoFactorAuthManager,
-                    $this->defaults,
-                    \OC::$server->getBruteForceThrottler()
-                );
-            } else {
-                $loginController = new \OC\Core\Controller\LoginController(
-                'core',
-                    $this->getMockedRequest(),
-                    $this->userManager,
-                    $this->config,
-                    $this->session,
-                    $this->userSession,
-                    $this->urlGenerator,
-                    $this->logger,
-                    $this->twoFactorAuthManager,
-                    $this->defaults
-                );
-            }
-        } else {
-            if($parameters[8]->getName() === 'throttler') {
-                $loginController = new \OC\Core\Controller\LoginController(
-                    'core',
-                    $this->getMockedRequest(),
-                    $this->userManager,
-                    $this->config,
-                    $this->session,
-                    $this->userSession,
-                    $this->urlGenerator,
-                    $this->twoFactorAuthManager,
-                    \OC::$server->getBruteForceThrottler()
-                );
-            } else {
-                $loginController = new \OC\Core\Controller\LoginController(
-                'core',
-                    $this->getMockedRequest(),
-                    $this->userManager,
-                    $this->config,
-                    $this->session,
-                    $this->userSession,
-                    $this->urlGenerator,
-                    $this->logger,
-                    $this->twoFactorAuthManager
-                );
-            }
-        }
+		$loginController = new \OC\Core\Controller\LoginController(
+			'core',
+			$this->getMockedRequest(),
+			$this->userManager,
+			$this->config,
+			$this->session,
+			$this->userSession,
+			$this->urlGenerator,
+			$this->logger,
+			$this->twoFactorAuthManager,
+			$this->defaults,
+			\OC::$server->getBruteForceThrottler()
+		);
 
-		return $loginController->tryLogin($username, $password, '');
+		return $loginController->tryLogin($username, $password, NULL);
 	}
 }

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -49,6 +49,8 @@ class LoginController extends Controller {
 	private $logger;
 	/** @var Manager */
 	private $twoFactorAuthManager;
+    /** @var Defaults */
+    private $defaults;
 
 	public function __construct($appName,
 								IRequest $request,
@@ -67,6 +69,7 @@ class LoginController extends Controller {
 		$this->session = $session;
 		$this->logger = $logger;
 		$this->twoFactorAuthManager = $twoFactorAuthManager;
+        $this->defaults = new \OCP\Defaults();
 	}
 
 	private function getMockedRequest() {
@@ -102,31 +105,61 @@ class LoginController extends Controller {
 		$parameters = $class->getConstructor()->getParameters();
 
 		/** @var \OC\Core\Controller\LoginController $loginController */
-		if($parameters[8]->getName() === 'throttler') {
-			$loginController = new \OC\Core\Controller\LoginController(
-				'core',
-				$this->getMockedRequest(),
-				$this->userManager,
-				$this->config,
-				$this->session,
-				$this->userSession,
-				$this->urlGenerator,
-				$this->twoFactorAuthManager,
-				\OC::$server->getBruteForceThrottler()
-			);
-		} else {
-			$loginController = new \OC\Core\Controller\LoginController(
-			'core',
-				$this->getMockedRequest(),
-				$this->userManager,
-				$this->config,
-				$this->session,
-				$this->userSession,
-				$this->urlGenerator,
-				$this->logger,
-				$this->twoFactorAuthManager
-			);
-		}
+        if(\OCP\Util::getVersion()[0] >= 13) {
+            if($parameters[8]->getName() === 'throttler') {
+                $loginController = new \OC\Core\Controller\LoginController(
+                    'core',
+                    $this->getMockedRequest(),
+                    $this->userManager,
+                    $this->config,
+                    $this->session,
+                    $this->userSession,
+                    $this->urlGenerator,
+                    $this->twoFactorAuthManager,
+                    $this->defaults,
+                    \OC::$server->getBruteForceThrottler()
+                );
+            } else {
+                $loginController = new \OC\Core\Controller\LoginController(
+                'core',
+                    $this->getMockedRequest(),
+                    $this->userManager,
+                    $this->config,
+                    $this->session,
+                    $this->userSession,
+                    $this->urlGenerator,
+                    $this->logger,
+                    $this->twoFactorAuthManager,
+                    $this->defaults
+                );
+            }
+        } else {
+            if($parameters[8]->getName() === 'throttler') {
+                $loginController = new \OC\Core\Controller\LoginController(
+                    'core',
+                    $this->getMockedRequest(),
+                    $this->userManager,
+                    $this->config,
+                    $this->session,
+                    $this->userSession,
+                    $this->urlGenerator,
+                    $this->twoFactorAuthManager,
+                    \OC::$server->getBruteForceThrottler()
+                );
+            } else {
+                $loginController = new \OC\Core\Controller\LoginController(
+                'core',
+                    $this->getMockedRequest(),
+                    $this->userManager,
+                    $this->config,
+                    $this->session,
+                    $this->userSession,
+                    $this->urlGenerator,
+                    $this->logger,
+                    $this->twoFactorAuthManager
+                );
+            }
+        }
 
 		return $loginController->tryLogin($username, $password, '');
 	}

--- a/lib/Request.php
+++ b/lib/Request.php
@@ -22,15 +22,19 @@
 namespace OCA\LoginViaPost;
 
 class Request extends \OC\AppFramework\Http\Request {
-	public function passesCSRFCheck() {
-		return true;
+
+	public function passesCSRFCheck(): bool
+	{
+		return TRUE;
 	}
 
-	public function passesLaxCookieCheck() {
-		return true;
+	public function passesLaxCookieCheck(): bool
+	{
+		return TRUE;
 	}
 
-	public function passesStrictCookieCheck() {
-		return true;
+	public function passesStrictCookieCheck(): bool
+	{
+		return TRUE;
 	}
 }


### PR DESCRIPTION
#8 Fixed

Just passing OCP_Defaults to LoginController constructor as now required in Nextcloud 13.